### PR TITLE
Version 0.11.6.post1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.9]
+        python-version: [3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,8 @@ with open("../meson.build", "r") as f:
     for line in f.readlines():
         if "version" in line:
             version = line.split(": ")[-1].strip(""",'""")
+            break  # we want the first line with version
+
 # -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/gh_actions_requirements.txt
+++ b/gh_actions_requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.17.2
-scipy>=1.3.1
+scipy>=1.10.1
 pandas>=0.23.4
 lightgbm>=2.3.0
 pywavelets

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'scikit-digital-health',
     'c',
-    version: '0.11.6',
+    version: '0.11.6.post1',
     license: 'MIT',
     meson_version: '>=1.1',
 )

--- a/src/skdh/utility/_extensions/moving_moments.f95
+++ b/src/skdh/utility/_extensions/moving_moments.f95
@@ -358,6 +358,13 @@ subroutine moving_moments_3(n, x, wlen, skip, mean, sd, skew) bind(C, name="movi
         j = j + 1
     end do
 
+    where ((sd > -epsilon(sd(1))) .and. (sd < 0.0))
+        sd = -1.0 * sd
+    end where
+    where ((skew > -epsilon(sd(1))) .and. (skew < 0.0))
+        skew = -1.0 * skew
+    end where
+
     ! NOTE: currently, sd = M2, skew = M3, kurt = M4, so this order of computation matters
     mean = mean / wlen
     skew = sqrt(real(wlen)) * skew / sd**(3._c_double / 2._c_double)
@@ -442,6 +449,13 @@ subroutine moving_moments_4(n, x, wlen, skip, mean, sd, skew, kurt) bind(C, name
         
         j = j + 1
     end do
+
+    where ((sd > -epsilon(sd(1))) .and. (sd < 0.0))
+        sd = -1.0 * sd
+    end where
+    where ((skew > -epsilon(sd(1))) .and. (skew < 0.0))
+        skew = -1.0 * skew
+    end where
 
     ! NOTE: currently, sd = M2, skew = M3, kurt = M4, so this order of computation matters
     mean = mean / wlen

--- a/src/skdh/utility/_extensions/moving_moments.f95
+++ b/src/skdh/utility/_extensions/moving_moments.f95
@@ -72,9 +72,13 @@ subroutine mov_moments_2(n, x, wlen, skip, mean, sd) bind(C, name="mov_moments_2
         j = j + 1
     end do
 
+    where ((sd > -epsilon(sd(1))) .and. (sd < 0.0))
+        sd = -1.0 * sd
+    end where
+
     ! NOTE: currently, sd = M2, skew = M3, kurt = M4, so this order of computation matters
     mean = mean / wlen
-    sd = sqrt(sd / (wlen - 1))
+    sd = sqrt(sd / real(wlen - 1, c_double))
 
 end subroutine
 

--- a/src/skdh/utility/math.py
+++ b/src/skdh/utility/math.py
@@ -4,7 +4,9 @@ Utility math functions
 Lukas Adamowicz
 Copyright (c) 2021. Pfizer Inc. All rights reserved.
 """
-from numpy import moveaxis, ascontiguousarray, full, nan
+from warnings import warn
+
+from numpy import moveaxis, ascontiguousarray, full, nan, isnan
 
 from skdh.utility import _extensions
 from skdh.utility.windowing import get_windowed_view
@@ -354,6 +356,9 @@ def moving_skewness(a, w_len, skip, trim=True, axis=-1, return_previous=True):
 
     res = _extensions.moving_skewness(x, w_len, skip, trim, return_previous)
 
+    if isnan(res).any():
+        warn("NaN values present in output, possibly due to catastrophic cancellation.")
+
     # move computation axis back to original place and return
     if return_previous:
         return tuple(moveaxis(i, -1, axis) for i in res)
@@ -473,6 +478,9 @@ def moving_kurtosis(a, w_len, skip, trim=True, axis=-1, return_previous=True):
         )
 
     res = _extensions.moving_kurtosis(x, w_len, skip, trim, return_previous)
+
+    if isnan(res).any():
+        warn("NaN values present in output, possibly due to catastrophic cancellation.")
 
     # move computation axis back to original place and return
     if return_previous:

--- a/test/features/test_features_core.py
+++ b/test/features/test_features_core.py
@@ -81,7 +81,7 @@ class TestNormalizeAxes:
 
 
 class TestBank:
-    def setup(self):
+    def setup_method(self):
         pass
 
     def test_dunder_methods(self):

--- a/test/utility/test_math.py
+++ b/test/utility/test_math.py
@@ -128,6 +128,31 @@ class BaseMovingStatsTester:
             self.function(x, 150, 3)
             self.function(x, 150, 151)
 
+    @pytest.mark.parametrize("trim", (True, False))
+    @pytest.mark.parametrize("skip", (1, 2, 7, 150, 300))
+    def test_constant(self, skip, trim, np_rng):
+        wlen = 250  # constant
+        x = full(2000, np_rng.random())
+        xw = get_windowed_view(x, wlen, skip)
+
+        if isinstance(self.truth_function, Iterable):
+            truth = []
+            for tf, tkw in zip(self.truth_function, self.truth_kw):
+                truth.append(self.get_truth(tf, x, xw, wlen, skip, trim, tkw))
+
+            pred = self.function(x, wlen, skip, trim=trim)
+
+            for p, t in zip(pred, truth):
+                assert allclose(p, t, equal_nan=True)
+        else:
+            truth = self.get_truth(
+                self.truth_function, x, xw, wlen, skip, trim, self.truth_kw
+            )
+
+            pred = self.function(x, wlen, skip, trim=trim)
+
+            assert allclose(pred, truth, equal_nan=True)
+
 
 class TestMovingMean(BaseMovingStatsTester):
     function = staticmethod(moving_mean)


### PR DESCRIPTION
- Fixed an issue where for constant value input moving moments could result in improper nan values
- Set skewness and kurtosis values to nan under some divide by zero conditions, likely caused by catastrophic cancellation

Fixes #101 